### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Simple library for the DF Robot micro:Maqueen BBC Micro:Bit Robot
 category=Device Control
 url=https://github.com/kd8bxp/micro-Maqueen-Arduino-Library
 architectures=*
+depends=Adafruit microbit Library


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

NOTE: I did not add the New_Ping library dependency because that library is not in the Arduino Library Manager index. If this library can be made to work with the [original NewPing library](https://bitbucket.org/teckel12/arduino-new-ping/wiki/Home) instead of that Particle thing, then I can add the NewPing library to the `depends` field, as the NewPing library is in the Library Manager index.