### PR TITLE
edit: updated LED matrix related codes and adjusted indentation

### DIFF
--- a/examples/Library_LED_Matrix_Demo/Library_LED_Matrix_Demo.ino
+++ b/examples/Library_LED_Matrix_Demo/Library_LED_Matrix_Demo.ino
@@ -6,101 +6,101 @@
 #include <Maqueen.h>
 Maqueen bot;
 
-Adafruit_Microbit_Matrix microbit;
+Adafruit_Microbit microbit;
 
 
     
 void setup() {  
   Serial.begin(9600);
   bot.begin();
-  microbit.begin();
+  microbit.matrix.begin();
 }
     
 void loop(){
 
   // The Images below are from the Adafruit microbit library.
   // Fill screen
-  microbit.fillScreen(LED_ON);
+  microbit.matrix.fillScreen(LED_ON);
   delay(1000);
 
   // draw a heart
-  microbit.show(microbit.HEART);
+  microbit.matrix.show(microbit.matrix.HEART);
   delay(1000);
   //empty heart
-  microbit.show(microbit.EMPTYHEART);
+  microbit.matrix.show(microbit.matrix.EMPTYHEART);
   delay(1000);
   // draw a no cross
-  microbit.show(microbit.NO);
+  microbit.matrix.show(microbit.matrix.NO);
   delay(1000);
 
   // draw a yes check
-  microbit.show(microbit.YES);
+  microbit.matrix.show(microbit.matrix.YES);
   delay(1000);
  
   
-  microbit.clear();
+  microbit.matrix.clear();
 
   //These are included in the Adafruit Microbit library.
   // Draw a line 'by hand'
-  microbit.drawPixel(0, 0, LED_ON);
-  microbit.drawPixel(1, 1, LED_ON);
-  microbit.drawPixel(2, 2, LED_ON);
-  microbit.drawPixel(3, 3, LED_ON);
-  microbit.drawPixel(4, 4, LED_ON);
+  microbit.matrix.drawPixel(0, 0, LED_ON);
+  microbit.matrix.drawPixel(1, 1, LED_ON);
+  microbit.matrix.drawPixel(2, 2, LED_ON);
+  microbit.matrix.drawPixel(3, 3, LED_ON);
+  microbit.matrix.drawPixel(4, 4, LED_ON);
   // draw the 'opposite' line with drawline (easier!)
-  microbit.drawLine(0, 4, 4, 0, LED_ON);
+  microbit.matrix.drawLine(0, 4, 4, 0, LED_ON);
 
   delay(1000);
 
   // erase screen, draw a square
-  microbit.clear();
-  microbit.drawRect(0,0, 5, 5, LED_ON); // top left corner @ (0,0), 5 by 5 pixels size
+  microbit.matrix.clear();
+  microbit.matrix.drawRect(0,0, 5, 5, LED_ON); // top left corner @ (0,0), 5 by 5 pixels size
 
   delay(1000);
 
   // erase screen, draw a circle
-  microbit.clear();
-  microbit.drawCircle(2,2, 2, LED_ON); // center on 2, 2, radius 2
+  microbit.matrix.clear();
+  microbit.matrix.drawCircle(2,2, 2, LED_ON); // center on 2, 2, radius 2
 
   delay(1000);
 
   // erase screen, draw a filled triangle
-  microbit.clear();
-  microbit.fillTriangle(0,4, 2,0, 4,4, LED_ON); 
+  microbit.matrix.clear();
+  microbit.matrix.fillTriangle(0,4, 2,0, 4,4, LED_ON); 
 
   delay(1000);
 
 //These Images are included in the Maqueen Library
 //some are based off images on makecode.microbit.org
 // draw a custom made bitmap face
-  microbit.show(smile_bmp);
+  microbit.matrix.show(smile_bmp);
   delay(1000);
 
-  microbit.show(sad);
+  microbit.matrix.show(sad);
   delay(1000);
 
-  microbit.show(confused);
+  microbit.matrix.show(confused);
   delay(1000);
 
-  microbit.show(small_heart);
+  microbit.matrix.show(small_heart);
   delay(1000);
 
-  microbit.show(up_arrow);
+  microbit.matrix.show(up_arrow);
   delay(1000);
 
-  microbit.show(down_arrow);
+  microbit.matrix.show(down_arrow);
   delay(1000);
 
-  microbit.show(left_arrow);
+  microbit.matrix.show(left_arrow);
   delay(1000);
 
-  microbit.show(right_arrow);
+  microbit.matrix.show(right_arrow);
   delay(1000);
 
-  microbit.show(ghost);
+  microbit.matrix.show(ghost);
   delay(1000);
 
-  microbit.show(skull);
+  microbit.matrix.show(skull);
   delay(1000);
   
 }

--- a/examples/library_example1_motor/library_example1_motor.ino
+++ b/examples/library_example1_motor/library_example1_motor.ino
@@ -29,18 +29,18 @@ Maqueen bot;
 
 //NewPing.h and Adafruit_Microbit.h are inlcuded the library header
 //but still need to be invoked here.
-Adafruit_Microbit_Matrix microbit;
+Adafruit_Microbit microbit;
 
 void setup() {
   bot.begin();
-microbit.begin();
+microbit.matrix.begin();
 
   while (bot.readA()) { //wait for BTNA to be pushed
-microbit.print("A");
+microbit.matrix.print("A");
 }
 
-microbit.clear();
-microbit.show(smile_bmp);
+microbit.matrix.clear();
+microbit.matrix.show(smile_bmp);
 
 //Spin the motor to the right
 bot.motorRun(M1, CW, 50); //Motor Number, direction, speed (PWM)

--- a/examples/library_example2_avoid/library_example2_avoid.ino
+++ b/examples/library_example2_avoid/library_example2_avoid.ino
@@ -31,28 +31,28 @@ Maqueen bot;
 //NewPing.h and Adafruit_Microbit.h are inlcuded the library header
 //but still need to be invoked here.
 NewPing sonar(TRIGGER_PIN, ECHO_PIN, MAX_DISTANCE); // NewPing setup of pins and maximum distance.
-Adafruit_Microbit_Matrix microbit;
+Adafruit_Microbit microbit;
 
 
 void setup() {
   Serial.begin(9600);
   bot.begin();
-  microbit.begin();
-while (bot.readA()) { //wait for BTNA to be pushed
-microbit.print("A");
-}
-  microbit.clear();
-  microbit.show(smile_bmp);
-}
+  microbit.matrix.begin();
+  while (bot.readA()) { //wait for BTNA to be pushed
+    microbit.matrix.print("A");
+  }
+    microbit.matrix.clear();
+    microbit.matrix.show(smile_bmp);
+  }
 
 void loop() {
   bot.setSpeed(80); //percentage from 1 to 100
-while (sonar.ping_in() >= 5) {
-bot.forward();
-}
-bot.stop();
-bot.setSpeed(60);
-bot.spinLeft();
-delay(100);
-bot.stop();
+  while (sonar.ping_in() >= 5) {
+    bot.forward();
+  }
+  bot.stop();
+  bot.setSpeed(60);
+  bot.spinLeft();
+  delay(100);
+  bot.stop();
 }

--- a/examples/library_example3a_blink_led/library_example3a_blink_led.ino
+++ b/examples/library_example3a_blink_led/library_example3a_blink_led.ino
@@ -29,20 +29,20 @@ Maqueen bot;
 
 //NewPing.h and Adafruit_Microbit.h are inlcuded the library header
 //but still need to be invoked here.
-Adafruit_Microbit_Matrix microbit;
+Adafruit_Microbit microbit;
 
 void setup() {
   Serial.begin(9600);
-bot.begin(); //must include the begin (otherwise things don't work)  
-microbit.begin();
+  bot.begin(); //must include the begin (otherwise things don't work)  
+  microbit.matrix.begin();
 
-while (bot.readA()) { //wait for BTNA to be pushed
-microbit.print("A");
-}
+  while (bot.readA()) { //wait for BTNA to be pushed
+    microbit.matrix.print("A");
+  }
 
-microbit.clear();
-microbit.show(smile_bmp);
-}
+  microbit.matrix.clear();
+  microbit.matrix.show(smile_bmp);
+ }
 
 void loop() {
   digitalWrite(LED1,HIGH); //LED1 is defined in the library (left led)

--- a/examples/library_example4_ultrasonic_display/library_example4_ultrasonic_display.ino
+++ b/examples/library_example4_ultrasonic_display/library_example4_ultrasonic_display.ino
@@ -29,23 +29,23 @@ Maqueen bot;
 //NewPing.h and Adafruit_Microbit.h are inlcuded the library header
 //but still need to be invoked here.
 NewPing sonar(TRIGGER_PIN, ECHO_PIN, MAX_DISTANCE); // NewPing setup of pins and maximum distance.
-Adafruit_Microbit_Matrix microbit;
+Adafruit_Microbit microbit;
 
 void setup() {
   Serial.begin(9600);
   bot.begin();
-  microbit.begin();
-while (bot.readA()) { //wait for BTNA to be pushed
-microbit.print("A");
-}
-  microbit.clear();
-  microbit.show(smile_bmp);
+  microbit.matrix.begin();
+  while (bot.readA()) { //wait for BTNA to be pushed
+    microbit.matrix.print("A");
+  }
+  microbit.matrix.clear();
+  microbit.matrix.show(smile_bmp);
 
 }
 
 void loop() {
   int us = sonar.ping_in();
-  microbit.print(us);
+  microbit.matrix.print(us);
   Serial.println(us);
   delay(1000);
 

--- a/examples/library_example5_ble_controller/library_example5_ble_controller.ino
+++ b/examples/library_example5_ble_controller/library_example5_ble_controller.ino
@@ -29,9 +29,9 @@ void setup() {
   microbit.BTLESerial.setLocalName("microbit");
 
   // Start LED matrix driver after radio (required)
-  microbit.begin();
-microbit.clear();
-microbit.show(smile_bmp);
+  microbit.matrix.begin();
+  microbit.matrix.clear();
+  microbit.matrix.show(smile_bmp);
 }
 
 /**************************************************************************/
@@ -81,4 +81,3 @@ switch (buttnum) {
   }
  }
 }
-

--- a/examples/library_example5a_gamepad_control/library_example5a_gamepad_control.ino
+++ b/examples/library_example5a_gamepad_control/library_example5a_gamepad_control.ino
@@ -30,7 +30,7 @@ https://kd8bxp.blogspot.com/
 #include "NRF51_Radio_library.h" //https://github.com/tipih/NRF51_Radio_library
 
 Maqueen bot;
-Adafruit_Microbit_Matrix microbit;      
+Adafruit_Microbit microbit;      
 NRF51_Radio MicrobitRadio = NRF51_Radio();  
 
 static long currentMillis;
@@ -42,19 +42,19 @@ void setup() {
   Serial.begin(115200);
   bot.begin();
   Serial.println("Gamepad Control demo ready!");
-  microbit.begin();
+  microbit.matrix.begin();
   MicrobitRadio.enable();
   MicrobitRadio.setGroup(10);
   MicrobitRadio.setFrequencyBand(50);
   Serial.println("Radio running");
-  microbit.clear();
-microbit.show(smile_bmp);
+  microbit.matrix.clear();
+  microbit.matrix.show(smile_bmp);
 }
 
 void loop() {
  
 //Check if there is any data in the buffer
- FrameBuffer* myData = MicrobitRadio.recv();
+  FrameBuffer* myData = MicrobitRadio.recv();
   if (myData != NULL) {
     Serial.print(myData->length);
     Serial.print("    ");

--- a/examples/library_example6_ir_remote_control/library_example6_ir_remote_control.ino
+++ b/examples/library_example6_ir_remote_control/library_example6_ir_remote_control.ino
@@ -44,51 +44,49 @@ Maqueen bot;
 //NewPing.h and Adafruit_Microbit.h are inlcuded the library header
 //but still need to be invoked here.
 NewPing sonar(TRIGGER_PIN, ECHO_PIN, MAX_DISTANCE); // NewPing setup of pins and maximum distance.
-Adafruit_Microbit_Matrix microbit;
+Adafruit_Microbit microbit;
 
 int byteValue;
 int speed = 50; //50% of full speed
 
 void setup() {
-   Serial.begin(9600);
+  Serial.begin(9600);
   bot.begin();
-  microbit.begin();
-  microbit.clear();
-  microbit.show(smile_bmp);
+  microbit.matrix.begin();
+  microbit.matrix.clear();
+  microbit.matrix.show(smile_bmp);
 
 }
 
 void loop() {
  byteValue = bot.readIR();
 
-switch (byteValue) {
-  case 0:
-  bot.stop();
-  break;
-  case UP:
-  bot.setSpeed(speed);
-  bot.forward();
-  break;
-  case DOWN:
-  bot.setSpeed(speed);
-  bot.backward();
-  break;
-  case LEFT:
-  bot.setSpeed(speed);
-  bot.spinLeft();
-  break;
-  case RIGHT:
-  bot.setSpeed(speed);
-  bot.spinRight();
-  break;
-  case SETUP:
-  bot.stop();
-  break;
-  default:
-  bot.stop();
-  break;
+  switch (byteValue) {
+    case 0:
+      bot.stop();
+      break;
+    case UP:
+      bot.setSpeed(speed);
+      bot.forward();
+      break;
+    case DOWN:
+      bot.setSpeed(speed);
+      bot.backward();
+      break;
+    case LEFT:
+      bot.setSpeed(speed);
+      bot.spinLeft();
+      break;
+    case RIGHT:
+      bot.setSpeed(speed);
+      bot.spinRight();
+      break;
+    case SETUP:
+      bot.stop();
+      break;
+    default:
+      bot.stop();
+      break;
+  }
+  byteValue = 0; 
 }
- byteValue = 0; 
-}
-
-

--- a/examples/library_example6a_get_ir_codes/library_example6a_get_ir_codes.ino
+++ b/examples/library_example6a_get_ir_codes/library_example6a_get_ir_codes.ino
@@ -26,15 +26,15 @@ https://kd8bxp.blogspot.com/
 #include <Maqueen.h>
 Maqueen bot;
 
-Adafruit_Microbit_Matrix microbit;
+Adafruit_Microbit microbit;
 
 int byteValue;
 
 void setup() {
-   Serial.begin(9600);
+  Serial.begin(9600);
   bot.begin();
-  microbit.begin();
-  microbit.clear();
+  microbit.matrix.begin();
+  microbit.matrix.clear();
 
 }
 
@@ -48,10 +48,10 @@ void loop() {
    * A lot of trail and error has to be used.
    */
 
- byteValue = bot.readIR();
- if (byteValue != 0) {
-Serial.println(byteValue);
-microbit.print(byteValue);
-delay(100);
- }
+  byteValue = bot.readIR();
+  if (byteValue != 0) {
+    Serial.println(byteValue);
+    microbit.matrix.print(byteValue);
+    delay(100);
+  }
 }

--- a/examples/library_example7_line_follow/library_example7_line_follow.ino
+++ b/examples/library_example7_line_follow/library_example7_line_follow.ino
@@ -30,7 +30,7 @@ Maqueen bot;
 
 //NewPing.h and Adafruit_Microbit.h are inlcuded the library header
 //but still need to be invoked here.
-Adafruit_Microbit_Matrix microbit;
+Adafruit_Microbit microbit;
 
 //on the makeblock line map
 //Black Line returns a Zero (0)
@@ -41,30 +41,29 @@ int speed = 10; //this is a percentage from 1 to 100
 void setup() {
   Serial.begin(9600);
   bot.begin();
- microbit.begin();
+  microbit.matrix.begin();
 
-while (bot.readA()) { //wait for BTNA to be pushed
-microbit.print("A");
-}
+  while (bot.readA()) { //wait for BTNA to be pushed
+    microbit.matrix.print("A");
+  }
 
-microbit.clear();
-microbit.show(smile_bmp);
+  microbit.matrix.clear();
+  microbit.matrix.show(smile_bmp);
 }
 
 void loop() {
 
  bot.setSpeed(speed);
- if (bot.readPatrolLeft() == 0 && bot.readPatrolRight() == 0) {
- bot.forward(); 
- }
- if (bot.readPatrolLeft() == 1 && bot.readPatrolRight() == 0) {
-  bot.right();
- }
- if (bot.readPatrolRight() == 1 && bot.readPatrolLeft() == 0) {
-  bot.left();
-   }
- if (bot.readPatrolRight() == 1 && bot.readPatrolLeft() == 1) {
-  bot.spinLeft();
- }
+  if (bot.readPatrolLeft() == 0 && bot.readPatrolRight() == 0) {
+    bot.forward(); 
+  }
+  if (bot.readPatrolLeft() == 1 && bot.readPatrolRight() == 0) {
+    bot.right();
+  }
+  if (bot.readPatrolRight() == 1 && bot.readPatrolLeft() == 0) {
+    bot.left();
+  }
+  if (bot.readPatrolRight() == 1 && bot.readPatrolLeft() == 1) {
+    bot.spinLeft();
+  }
 }
-

--- a/examples/library_example8_light_sensor_based_on_Sparkfun_code/library_example8_light_sensor_based_on_Sparkfun_code.ino
+++ b/examples/library_example8_light_sensor_based_on_Sparkfun_code/library_example8_light_sensor_based_on_Sparkfun_code.ino
@@ -25,7 +25,7 @@
 #include <Maqueen.h>
 
 Maqueen bot;
-Adafruit_Microbit_Matrix microbit;
+Adafruit_Microbit microbit;
 // Any reading over this value will turn on the output LED
 const unsigned int THRESHOLD = 10;
 
@@ -43,34 +43,11 @@ void setup() {
 
   // Start serial communications
   Serial.begin(9600);
-microbit.begin();
-bot.begin();
+  microbit.matrix.begin();
+  bot.begin();
   // Set P junction pin to output low (GND)
   pinMode(P_JNCT_PIN, OUTPUT);
   digitalWrite(P_JNCT_PIN, LOW);
-
-  
-}
-
-void loop() {
-
-  // Read the amount of light falling on the LED
-  readLED();
-
-  // Print out the raw discharge time
-  //Serial.println(sen_time);
-  int number = sen_time/500;
-microbit.print(number);
- Serial.println(number);
-  // If the light is below a certain level (discharge time is over the
-  // threshold), turn on the output LED
-  if ( number < THRESHOLD ) {
-    bot.setSpeed(30);
-    bot.forward();
-  } else {
-    bot.stop();
-  }
-  
 }
 
 void readLED() {
@@ -94,8 +71,27 @@ void readLED() {
       break;
     }
 
+  }
+
+  sen_time = t;
 }
 
-sen_time = t;
+void loop() {
 
+  // Read the amount of light falling on the LED
+  readLED();
+
+  // Print out the raw discharge time
+  //Serial.println(sen_time);
+  int number = sen_time/500;
+  microbit.matrix.print(number);
+  Serial.println(number);
+  // If the light is below a certain level (discharge time is over the
+  // threshold), turn on the output LED
+  if ( number < THRESHOLD ) {
+    bot.setSpeed(30);
+    bot.forward();
+  } else {
+    bot.stop();
+  }
 }


### PR DESCRIPTION
Hello.

I tried your example code on micro:bit maqueen, and found that "library_example5_ble_controller" was not working on my environment.
This was because of the definition of `microbit` on L10.
In other examples the definition was as below:
```
Adafruit_Microbit microbit;
```
However, in the example the definition was like:
```
Adafruit_Microbit_Matrix microbit;
```
This differenced seemed to cause the compilation error.
So I fixed codes as follows:

```
//definition of "microbit"
Adafruit_Microbit microbit;

//led matrix related codes
microbit.matrix.begin();
```
and then now the example app works.

I also changed other example codes (excluding codes in "More" folder), for I thought it may be a bit confusing if they aren't.

And, I adjusted the indentation to improve the readability.

I confirmed that all the examples that I edited are compilable and work on my micro maqueen.

Sorry for my poor English, and I hope this will help your repository.